### PR TITLE
Add module scripts and files for restoring Paperless environment

### DIFF
--- a/imageroot/actions/clone-module/50traefik
+++ b/imageroot/actions/clone-module/50traefik
@@ -1,0 +1,1 @@
+../restore-module/50traefik

--- a/imageroot/actions/restore-module/06copyenv
+++ b/imageroot/actions/restore-module/06copyenv
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import sys
+import json
+import agent
+
+request = json.load(sys.stdin)
+
+original_environment = request['environment']
+
+for evar in [
+        "TRAEFIK_HOST",
+        "TRAEFIK_HTTP2HTTPS",
+        "TRAEFIK_LETS_ENCRYPT",
+        "PAPERLESS_NGX_NAME",
+        "PAPERLESS_TIME_ZONE",
+        "PAPERLESS_OCR_LANGUAGE",
+        "PAPERLESS_COOKIE_PREFIX",
+        "PAPERLESS_ADMIN_USER",
+        "PAPERLESS_ADMIN_PASSWORD",
+        "PAPERLESS_ADMIN_MAIL",
+        "PAPERLESS_URL",
+        "PAPERLESS_TIKA_ENABLED",
+        "PAPERLESS_TIKA_GOTENBERG_ENDPOINT",
+        "PAPERLESS_TIKA_ENDPOINT",
+        "PHP_ENABLE_OPCACHE",
+        "PHP_MEMORY_LIMIT",
+    ]:
+    agent.set_env(evar, original_environment[evar])

--- a/imageroot/actions/restore-module/40restore-postgres
+++ b/imageroot/actions/restore-module/40restore-postgres
@@ -9,9 +9,9 @@ set -e -o pipefail
 exec 1>&2 # Redirect any output to the journal (stderr)
 
 mkdir -vp restore
-cat - >restore/ paperless_restore.sh <<'EOS'
+cat - >restore/paperless_restore.sh <<'EOS'
 # Read dump file from standard input:
-pg_restore --no-owner --no-privileges -U peperless -d paperless
+pg_restore --no-owner --no-privileges -U paperless -d paperless
 ec=$?
 docker_temp_server_stop
 exit $ec
@@ -27,7 +27,7 @@ podman run \
     --volume=./restore:/docker-entrypoint-initdb.d/:Z \
     --volume=postgres-data:/var/lib/postgresql/data:Z \
     --replace --name=restore_db \
-    --env-file=%S/state/database.env \
+    --env-file=database.env \
     --env TZ=UTC \
     "${POSTGRES_IMAGE}" <  paperless.pg_dump
 

--- a/imageroot/actions/restore-module/40restore-postgres
+++ b/imageroot/actions/restore-module/40restore-postgres
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e -o pipefail
+exec 1>&2 # Redirect any output to the journal (stderr)
+
+mkdir -vp restore
+cat - >restore/ paperless_restore.sh <<'EOS'
+# Read dump file from standard input:
+pg_restore --no-owner --no-privileges -U peperless -d paperless
+ec=$?
+docker_temp_server_stop
+exit $ec
+EOS
+
+# Override the image /docker-entrypoint-initdb.d contents, to restore the
+# DB dump file. The container will be stopped at the end
+
+podman run \
+    --rm \
+    --interactive \
+    --network=none \
+    --volume=./restore:/docker-entrypoint-initdb.d/:Z \
+    --volume=postgres-data:/var/lib/postgresql/data:Z \
+    --replace --name=restore_db \
+    --env-file=%S/state/database.env \
+    --env TZ=UTC \
+    "${POSTGRES_IMAGE}" <  paperless.pg_dump
+
+# If the restore is successful, clean up:
+rm -rfv restore/  paperless.pg_dump

--- a/imageroot/actions/restore-module/50traefik
+++ b/imageroot/actions/restore-module/50traefik
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+# Configure traefik route for mattermost
+
+import os
+import sys
+import agent
+import agent.tasks
+
+# Find default traefik instance for current node
+default_traefik_id = agent.resolve_agent_id('traefik@node')
+if default_traefik_id is None:
+    sys.exit(2)
+
+# Configure traefik virtual host
+response = agent.tasks.run(
+    agent_id=default_traefik_id,
+    action='set-route',
+    data={
+        'instance': os.environ['MODULE_ID'],
+        'url': f'http://127.0.0.1:{os.environ["TCP_PORT"]}',
+        'host': os.environ["TRAEFIK_HOST"],
+        'lets_encrypt': os.environ["TRAEFIK_LETS_ENCRYPT"] == True,
+        'http2https': os.environ["TRAEFIK_HTTP2HTTPS"] == True
+    },
+)
+
+# Check if traefik configuration has been successfull
+agent.assert_exp(response['exit_code'] == 0)

--- a/imageroot/actions/restore-module/70systemd
+++ b/imageroot/actions/restore-module/70systemd
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+set -e
+
+# Redirect any output to the journal (stderr)
+exec 1>&2
+
+# Enable and restart the service
+systemctl --user enable --now paperless.service

--- a/imageroot/bin/module-cleanup-state
+++ b/imageroot/bin/module-cleanup-state
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+rm -vf paperless.pg_dump

--- a/imageroot/bin/module-dump-state
+++ b/imageroot/bin/module-dump-state
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+
+echo "Dumping paperless postgres database"
+podman exec paperless-pgsql pg_dump -U paperless --format=c  paperless > paperless.pg_dump

--- a/imageroot/etc /state-include.conf
+++ b/imageroot/etc /state-include.conf
@@ -1,0 +1,8 @@
+volumes/paperlessngx-data
+volumes/paperlessngx-media
+volumes/paperlessngx-export
+volumes/paperlessngx-consume
+volumes/paperless-redis-data
+volumes/postgres-data
+state/paperless.pg_dump
+state/database.env


### PR DESCRIPTION
This pull request adds the necessary scripts and files for restoring the Paperless environment. It includes scripts for cloning modules, restoring module environment variables, restoring the PostgreSQL database dump, restoring the Traefik route, and cleaning up the module state. Additionally, it adds the state-include.conf file and related volumes and state files.