### PR TITLE
Add environment variables for database configuration

### DIFF
--- a/imageroot/systemd/user/paperless-server.service
+++ b/imageroot/systemd/user/paperless-server.service
@@ -28,6 +28,7 @@ ExecStart=/usr/bin/podman run \
     --replace --name=%N \
     --env-file=smarthost.env \
     --env=PAPERLESS_* \
+    --env=PAPERLESS_DBENGINE=postgresql \
     --env=PAPERLESS_DBHOST=127.0.0.1 \
     --env=PAPERLESS_DBNAME=${POSTGRES_DATABASE} \
     --env=PAPERLESS_DBUSER=${POSTGRES_USER} \

--- a/imageroot/systemd/user/paperless-server.service
+++ b/imageroot/systemd/user/paperless-server.service
@@ -14,6 +14,7 @@ After=paperless-redis.service paperless-pgsql.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
+EnvironmentFile=%S/state/database.env
 WorkingDirectory=%S/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/ns8-paperless-ngx.pid %t/ns8-paperless-ngx.ctr-id
@@ -27,6 +28,10 @@ ExecStart=/usr/bin/podman run \
     --replace --name=%N \
     --env-file=smarthost.env \
     --env=PAPERLESS_* \
+    --env=PAPERLESS_DBHOST=127.0.0.1 \
+    --env=PAPERLESS_DBNAME=${POSTGRES_DATABASE} \
+    --env=PAPERLESS_DBUSER=${POSTGRES_USER} \
+    --env=PAPERLESS_DBPASS=${POSTGRES_PASSWORD} \
     --volume=paperlessngx-data:/usr/src/paperless/data \
     --volume=paperlessngx-media:/usr/src/paperless/media \
     --volume=paperlessngx-export:/usr/src/paperless/export \


### PR DESCRIPTION
This pull request adds the necessary environment variables for configuring the database in the paperless-server.service file. The PAPERLESS_DBENGINE, PAPERLESS_DBHOST, PAPERLESS_DBNAME, PAPERLESS_DBUSER, and PAPERLESS_DBPASS variables are added to enable the connection to the PostgreSQL database.